### PR TITLE
Fail E2E test when API credential prompt is missing

### DIFF
--- a/e2e/src/pages/AppCatalogPage.ts
+++ b/e2e/src/pages/AppCatalogPage.ts
@@ -148,8 +148,7 @@ export class AppCatalogPage extends BasePage {
       count = await textInputs.count();
       this.logger.info(`Configuration form detected with ${count} input field(s)`);
     } catch (error) {
-      this.logger.info('No configuration required - no input fields found');
-      return;
+      throw new Error('This app should prompt for API credentials');
     }
 
     // Check if all text fields have values - if so, accept defaults


### PR DESCRIPTION
The `configureApiIntegrationIfNeeded()` method silently returned when credential input fields weren't found during install. Since this app always requires API credentials, the test should fail if the prompt doesn't appear rather than passing with unconfigured credentials.