### PR TITLE
Ignore disallowed actions/cache versions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,5 @@ updates:
         versions: [">=8.0.0"]
       - dependency-name: "actions/upload-artifact"
         versions: [">=7.0.0"]
+      - dependency-name: "actions/cache"
+        versions: [">=5.0.4"]


### PR DESCRIPTION
Add ignore rule for actions/cache >= 5.0.4 in dependabot config.
v5.0.4 is not in the org's allowed GitHub Actions list and causes startup_failure.