### PR TITLE
Fix iframe strict mode violation in E2E tests

### DIFF
--- a/e2e/src/pages/OpenRouterToolkitPage.ts
+++ b/e2e/src/pages/OpenRouterToolkitPage.ts
@@ -201,7 +201,7 @@ export class OpenRouterToolkitPage extends SocketNavigationPage {
         }
 
         // Verify iframe and form elements
-        await expect(this.page.locator('iframe')).toBeVisible({ timeout: 15000 });
+        await expect(this.page.locator('iframe').first()).toBeVisible({ timeout: 15000 });
         this.logger.info('Extension iframe loaded');
 
         const iframe: FrameLocator = this.page.frameLocator('iframe');

--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -17,12 +17,12 @@ test.describe('OpenRouter Toolkit Extension E2E Tests', () => {
   });
 
   test.describe('Extension Installation and Discovery', () => {
-    test('should verify OpenRouter Toolkit extension is installed', async ({ openRouterToolkitPage, appName }) => {
+    test('should verify OpenRouter Toolkit extension is installed', async ({ openRouterToolkitPage, appName, page }) => {
       // Navigate to Cases to access the extension socket
       await openRouterToolkitPage.navigateToNGSIEMCases();
 
       // Verify we're on the Cases page
-      const currentUrl = openRouterToolkitPage.page.url();
+      const currentUrl = page.url();
       expect(currentUrl).toMatch(/\/xdr\/cases/);
 
       logger.success(`${appName} extension is accessible from Cases page`);
@@ -71,7 +71,7 @@ test.describe('OpenRouter Toolkit Extension E2E Tests', () => {
       await openRouterToolkitPage.verifyExtensionRenders();
 
       // Verify iframe is present and visible
-      const iframe = page.locator('iframe');
+      const iframe = page.locator('iframe').first();
       await expect(iframe).toBeVisible({ timeout: 15000 });
 
       // Get the iframe locator for content checks


### PR DESCRIPTION
The Falcon console sometimes renders a hidden iframe alongside the app extension iframe, causing Playwright's strict mode to fail with "resolved to 2 elements" when using `locator('iframe')`. Adding `.first()` targets the first (visible) iframe and avoids the error. Also fixes a TypeScript error where a test accessed the protected `page` property directly instead of using the `page` fixture.

This was causing nightly E2E test failures in CI.