### PR TITLE
Use specific iframe selector to avoid Charlotte AI conflict

### DIFF
--- a/e2e/src/pages/OpenRouterToolkitPage.ts
+++ b/e2e/src/pages/OpenRouterToolkitPage.ts
@@ -201,10 +201,10 @@ export class OpenRouterToolkitPage extends SocketNavigationPage {
         }
 
         // Verify iframe and form elements
-        await expect(this.page.locator('iframe')).toBeVisible({ timeout: 15000 });
+        await expect(this.page.locator('iframe[name="portal"]')).toBeVisible({ timeout: 15000 });
         this.logger.info('Extension iframe loaded');
 
-        const iframe: FrameLocator = this.page.frameLocator('iframe');
+        const iframe: FrameLocator = this.page.frameLocator('iframe[name="portal"]');
 
         const requestTab = iframe.getByRole('tab', { name: /request/i });
         await expect(requestTab).toBeVisible({ timeout: 10000 });
@@ -229,7 +229,7 @@ export class OpenRouterToolkitPage extends SocketNavigationPage {
       async () => {
         this.logger.info('Verifying query form is present');
 
-        const iframe: FrameLocator = this.page.frameLocator('iframe');
+        const iframe: FrameLocator = this.page.frameLocator('iframe[name="portal"]');
 
         const queryInput = iframe.locator('textarea, input[type="text"]').first();
         await expect(queryInput).toBeVisible({ timeout: 10000 });
@@ -253,7 +253,7 @@ export class OpenRouterToolkitPage extends SocketNavigationPage {
       async () => {
         this.logger.info('Testing basic query form interaction');
 
-        const iframe: FrameLocator = this.page.frameLocator('iframe');
+        const iframe: FrameLocator = this.page.frameLocator('iframe[name="portal"]');
 
         const queryInput = iframe.getByRole('textbox', { name: /query/i });
         await queryInput.fill('What is this incident about?');

--- a/e2e/tests/foundry.spec.ts
+++ b/e2e/tests/foundry.spec.ts
@@ -71,11 +71,11 @@ test.describe('OpenRouter Toolkit Extension E2E Tests', () => {
       await openRouterToolkitPage.verifyExtensionRenders();
 
       // Verify iframe is present and visible
-      const iframe = page.locator('iframe');
+      const iframe = page.locator('iframe[name="portal"]');
       await expect(iframe).toBeVisible({ timeout: 15000 });
 
       // Get the iframe locator for content checks
-      const iframeContent = page.frameLocator('iframe');
+      const iframeContent = page.frameLocator('iframe[name="portal"]');
 
       // Verify main content loaded - look for Request/Response tabs or form elements
       const requestTab = iframeContent.getByRole('tab', { name: /request/i });


### PR DESCRIPTION
The Falcon console now includes a Charlotte AI iframe on every page. This causes Playwright's strict mode to fail with `locator('iframe') resolved to 2 elements` when the tests use the bare `iframe` selector.

This changes all iframe selectors from `iframe` to `iframe[name="portal"]` to specifically target the Foundry app iframe. The `name="portal"` attribute is set by the Foundry platform, so this selector works whether or not Charlotte AI is present.